### PR TITLE
Trim all location examples (v2.02)

### DIFF
--- a/en/activity-standard/iati-activities/iati-activity/location/activity-description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/activity-description.rst
@@ -5,7 +5,7 @@ Example usage of ``activity-description`` within a ``location`` of an ``iati-act
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 10, 12
 	
 

--- a/en/activity-standard/iati-activities/iati-activity/location/activity-description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/activity-description/narrative.rst
@@ -5,7 +5,7 @@ The ``narrative`` element can be used to declare freetext for the ``activity-des
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 8
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.

--- a/en/activity-standard/iati-activities/iati-activity/location/administrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/administrative.rst
@@ -9,7 +9,7 @@ Example usage of ``administrative`` within a ``location`` of an ``iati-activity`
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 13
 
 Note: Multiple administrative levels can be reported by repeating the ``administrative`` element:

--- a/en/activity-standard/iati-activities/iati-activity/location/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/description.rst
@@ -5,7 +5,7 @@ Example usage of ``description`` within a ``location`` of an ``iati-activity``.:
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 7, 9
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/location/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/description/narrative.rst
@@ -5,7 +5,7 @@ The ``narrative`` element can be used to declare freetext for the ``description`
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 8
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``xml:lang`` attribute.  Example not shown.

--- a/en/activity-standard/iati-activities/iati-activity/location/exactness.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/exactness.rst
@@ -7,7 +7,7 @@ Example usage of ``exactness`` within a ``location`` of an ``iati-activity``.
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 17
 
 

--- a/en/activity-standard/iati-activities/iati-activity/location/feature-designation.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/feature-designation.rst
@@ -7,7 +7,7 @@ Example usage of ``feature-designation`` within a ``location`` of an ``iati-acti
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 19
 
 

--- a/en/activity-standard/iati-activities/iati-activity/location/location-class.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/location-class.rst
@@ -7,7 +7,7 @@ Example usage of ``location-class`` within a ``location`` of an ``iati-activity`
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 18
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/location/location-id.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/location-id.rst
@@ -8,7 +8,7 @@ Example usage of ``location-id`` within a ``location`` of an ``iati-activity``..
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 3
 	
 Note: If the *GeographicVocabulary* *G2* (*Open Street Map*) is used, then the ``@code`` value should be of the form <OSM element>/<OSM identifier>

--- a/en/activity-standard/iati-activities/iati-activity/location/location-reach.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/location-reach.rst
@@ -7,7 +7,7 @@ Example usage of ``location-reach`` within a ``location`` of an ``iati-activity`
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 2
 
 

--- a/en/activity-standard/iati-activities/iati-activity/location/name.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/name.rst
@@ -5,7 +5,7 @@ Example usage of ``name`` within a ``location`` of an ``iati-activity``.:
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 4, 6
 	
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/location/name/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/name/narrative.rst
@@ -5,7 +5,7 @@ The ``narrative`` element can be used to declare freetext for the ``name`` child
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 5
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.

--- a/en/activity-standard/iati-activities/iati-activity/location/point.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/point.rst
@@ -7,7 +7,7 @@ Example usage of ``point`` within a ``location`` of an ``iati-activity``.
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 14, 16
 
 

--- a/en/activity-standard/iati-activities/iati-activity/location/point/pos.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/point/pos.rst
@@ -5,7 +5,7 @@ Example usage of ``pos``, a child element of the ``point`` element of ``location
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
-	:end-before: <!--location ends-->
+	:end-before: <!--location-single ends-->
 	:emphasize-lines: 15
 
 Changelog


### PR DESCRIPTION
@stevieflow points out this fix in #318.

In fact, all location examples are really really long because the end tag is wrong. This PR fixes all of them.

It would be great to get this merged – the location examples are all really long and needlessly confusing as a result of this bug.