### PR TITLE
Corrects namespace URL

### DIFF
--- a/en/namespaces-extensions.rst
+++ b/en/namespaces-extensions.rst
@@ -17,7 +17,7 @@ The first approach allows reporting organisations to invent any required markup 
 
 .. code-block:: xml
 
-    <iati-activity xmlns:acme=”http://example.org/acme/ns#”>
+    <iati-activity xmlns:acme="http://example.org/acme/ns#">
 
     ...
 


### PR DESCRIPTION
In the original file, the URL for the namespace seems to be encoded within two different " characters.  This causes validation problems, if you use the example.  Have fixed from ”http://example.org/acme/ns#” to "http://example.org/acme/ns#" on line 20 only