### PR TITLE
Adds guidance for namespaces in 2.02

### DIFF
--- a/en/namespaces-extensions.rst
+++ b/en/namespaces-extensions.rst
@@ -21,7 +21,7 @@ The first approach allows reporting organisations to invent any required markup 
 
     ...
 
-    <acme:risk-level>3</acme:risk-level>
+      <acme:risk-level>3</acme:risk-level>
 
     ...
 
@@ -32,18 +32,37 @@ In this example, ACME has defined its own namespace using the URL ``http://examp
 
 Adding XML namespaces in versions 2.0x
 --------------
-Please note: when adding XML namespaces in versions 2.0x of the IATI standard, the namespace elements should be included at the end of the document, after elements in the schema.  Example:
+Please note: elements must occur in the order they are specified in the Schema.  When adding XML namespaces in versions 2.0x of the IATI standard, they should be placed as the last element.  At the activity level, they must only be included at the end of the activity (before </iati-activity>).  If added as a subelement, the namespace element must be placed as the last subelement.  Example:
 
-
+1) XML namespace at activity level
 .. code-block:: xml
 
     <iati-activity xmlns:acme="http://example.org/acme/ns#">
 
     ...
-    </fss>
-    <acme:risk-level>3</acme:risk-level>
+    
+      </fss>
+      <acme:risk-level>3</acme:risk-level>
 
     ...
 
     </iati-activity>
 
+2) XML namespace as a subelement within transaction
+.. code-block:: xml
+
+    <iati-activity xmlns:acme="http://example.org/acme/ns#">
+    
+    ...
+    
+      <transaction>
+    
+    ...
+    
+        </value>
+        <acme:risk-level>3</acme:risk-level>
+      </transaction>
+    
+    ...
+    
+    </iati-activity>

--- a/en/namespaces-extensions.rst
+++ b/en/namespaces-extensions.rst
@@ -29,3 +29,21 @@ The first approach allows reporting organisations to invent any required markup 
 
 In this example, ACME has defined its own namespace using the URL ``http://example.org/acme/ns#`` and mapped that to the prefix ``acme``.  It then adds the new element, ``acme:risk-level``, to provide information about its risk assessment for the activity.  IATI users who don’t recognise the ``http://example.org/acme/ns#`` namespace are required to ignore the ``acme:risk element`` rather than reporting an error, so the extended markup does not harm compatibility.  Users who are familiar with the namespace, however, can take advantage of the additional information.
 
+
+Adding XML namespaces in versions 2.0x
+--------------
+Please note: when adding XML namespaces in versions 2.0x of the IATI standard, the namespace elements should be included at the end of the document, after elements in the schema.  Example:
+
+
+.. code-block:: xml
+
+    <iati-activity xmlns:acme="http://example.org/acme/ns#">
+
+    ...
+    </fss>
+    <acme:risk-level>3</acme:risk-level>
+
+    ...
+
+    </iati-activity>
+


### PR DESCRIPTION
From investigation I understand that namespaces in 2.0x can only appear at the end of any document, *after* the last schema element.  Have tried to draft something to support this.  By all means check and change!