### PR TITLE
Remove example highlighting

### DIFF
--- a/en/activity-standard/iati-activities/iati-activity/activity-date.rst
+++ b/en/activity-standard/iati-activities/iati-activity/activity-date.rst
@@ -11,15 +11,14 @@ Example ``activity-date`` for an``iati-activity``.
 
 	<activity-date iso-date="2012-04-28" type="1" />
 
-| The ``activity-date`` element can be repeated in any ``iati-activity``.    
+| The ``activity-date`` element can be repeated in any ``iati-activity``.
 | In this example four ``activity-date`` are declared.
 
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
-	:start-after: <!--activity-date starts-->	
+	:start-after: <!--activity-date starts-->
 	:end-before: <!--activity-date ends-->
-	:emphasize-lines: 1, 4, 5, 6 	
-	
+
 Note: In some cases, not all *ActivityDateType* codes can be declared, depending on the ``activity-status`` of the ``iati-activity``
 
 | Note: All instances of the *ActivityDateType* code *2* & *4* (actual dates) are not expected to be in the *future*.

--- a/en/activity-standard/iati-activities/iati-activity/activity-date/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/activity-date/narrative.rst
@@ -6,22 +6,20 @@ The ``narrative`` child element can be used to declare freetext for the ``activi
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
-	:start-after: <!--activity-date starts-->	
+	:start-after: <!--activity-date starts-->
 	:end-before: <!--activity-date ends-->
-	:emphasize-lines: 2	
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.
 
 | One example illustrated below:
-		
+
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
-	:start-after: <!--activity-date starts-->	
+	:start-after: <!--activity-date starts-->
 	:end-before: <!--activity-date ends-->
-	:emphasize-lines: 3
-	
+
 Changelog
 ~~~~~~~~~
 2.01
 ^^^^
-| The ``narrative`` element was introduced in 2.01. 
+| The ``narrative`` element was introduced in 2.01.

--- a/en/activity-standard/iati-activities/iati-activity/budget.rst
+++ b/en/activity-standard/iati-activities/iati-activity/budget.rst
@@ -12,7 +12,7 @@ Example ``budget`` for an ``iati-activity``.
 	<budget type="1" status="1">
 	...
 	</budget>
-	
+
 | Note: If the @type attribute is omitted, then *BudgetType* code *1* (Original) is assumed.
 | Similarly, if the @status attribute is omitted, then *BudgetStatus* code *1* (Indicative) is assumed.
 
@@ -22,9 +22,8 @@ Example ``budget`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--budget starts-->
 	:end-before: <!--budget ends-->
-	:emphasize-lines: 1, 5
 
-| The ``budget`` element can be repeated in any ``iati-activity``.      
+| The ``budget`` element can be repeated in any ``iati-activity``.
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/budget/period-end.rst
+++ b/en/activity-standard/iati-activities/iati-activity/budget/period-end.rst
@@ -9,4 +9,4 @@ Example usage of ``period-end`` of ``budget`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--budget starts-->
 	:end-before: <!--budget ends-->
-	:emphasize-lines: 3
+

--- a/en/activity-standard/iati-activities/iati-activity/budget/period-start.rst
+++ b/en/activity-standard/iati-activities/iati-activity/budget/period-start.rst
@@ -9,4 +9,4 @@ Example usage of ``period-start`` of ``budget`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--budget starts-->
 	:end-before: <!--budget ends-->
-	:emphasize-lines: 2
+

--- a/en/activity-standard/iati-activities/iati-activity/budget/value.rst
+++ b/en/activity-standard/iati-activities/iati-activity/budget/value.rst
@@ -12,7 +12,6 @@ Example usage of ``value`` of ``budget`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--budget starts-->
 	:end-before: <!--budget ends-->
-	:emphasize-lines: 4
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/conditions.rst
+++ b/en/activity-standard/iati-activities/iati-activity/conditions.rst
@@ -17,11 +17,11 @@ Example ``conditions`` for an ``iati-activity``.
      <conditions attached="1">
      ...
      </conditions>
-     
-| Full example with all child elements:     
-     
+
+| Full example with all child elements:
+
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--conditions starts-->
 	:end-before: <!--conditions ends-->
-	:emphasize-lines: 1, 6
+

--- a/en/activity-standard/iati-activities/iati-activity/conditions/condition.rst
+++ b/en/activity-standard/iati-activities/iati-activity/conditions/condition.rst
@@ -8,7 +8,6 @@ Example ``condition`` child element of ``conditions`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--conditions starts-->
 	:end-before: <!--conditions ends-->
-	:emphasize-lines: 2, 5
 
 | The ``condition`` element can be repeated in any ``conditions`` of an ``iati-activity``.
 

--- a/en/activity-standard/iati-activities/iati-activity/conditions/condition/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/conditions/condition/narrative.rst
@@ -6,17 +6,15 @@ The ``narrative`` child element can be used to declare freetext for the ``condit
 	:language: xml
 	:start-after: <!--conditions starts-->
 	:end-before: <!--conditions ends-->
-	:emphasize-lines: 3	
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
-		
+
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--conditions starts-->
 	:end-before: <!--conditions ends-->
-	:emphasize-lines: 4
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info.rst
@@ -18,7 +18,6 @@ Example ``contact-info`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 1, 20
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/department.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/department.rst
@@ -6,8 +6,7 @@ Example ``department`` within ``contact-info`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 5, 7
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/department/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/department/narrative.rst
@@ -6,7 +6,6 @@ The ``narrative`` child element can be used to declare freetext for the ``depart
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 6
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/email.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/email.rst
@@ -6,4 +6,4 @@ Example ``email`` within ``contact-info`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 15
+

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/job-title.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/job-title.rst
@@ -6,7 +6,6 @@ Example ``job-title`` within ``contact-info`` of an ``iati-activity``
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 11, 13
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/job-title/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/job-title/narrative.rst
@@ -6,7 +6,6 @@ The ``narrative`` child element can be used to declare freetext for the ``job-ti
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 12
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/mailing-address.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/mailing-address.rst
@@ -6,7 +6,6 @@ Example ``mailing-address`` within ``contact-info`` of an ``iati-activity``
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 17, 19
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/mailing-address/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/mailing-address/narrative.rst
@@ -6,7 +6,6 @@ The ``narrative`` child element can be used to declare freetext for the ``mailin
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 18
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/organisation.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/organisation.rst
@@ -6,7 +6,6 @@ Example ``organisation`` within ``contact-info`` of an ``iati-activity``
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 2, 4
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/organisation/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/organisation/narrative.rst
@@ -6,7 +6,6 @@ The ``narrative`` child element can be used to declare freetext for the ``organi
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 3
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/person-name.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/person-name.rst
@@ -6,7 +6,6 @@ Example ``person-name`` within ``contact-info`` of an ``iati-activity``
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 8, 10
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/person-name/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/person-name/narrative.rst
@@ -6,7 +6,6 @@ The ``narrative`` child element can be used to declare freetext for the ``person
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 9
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/telephone.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/telephone.rst
@@ -6,4 +6,4 @@ Example ``telephone`` within ``contact-info`` of an ``iati-activity``
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 14
+

--- a/en/activity-standard/iati-activities/iati-activity/contact-info/website.rst
+++ b/en/activity-standard/iati-activities/iati-activity/contact-info/website.rst
@@ -6,8 +6,7 @@ Example ``website`` within ``contact-info`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--contact-info starts-->
 	:end-before: <!--contact-info ends-->
-	:emphasize-lines: 16
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/country-budget-items.rst
+++ b/en/activity-standard/iati-activities/iati-activity/country-budget-items.rst
@@ -11,17 +11,16 @@ Example ``country-budget-items`` for an ``iati-activity``.
     <country-budget-items vocabulary="2">
 	...
     </country-budget-items>
-    
+
 Full example with all child elements:
 
 .. code-block:: xml
-	:emphasize-lines: 1, 7
-	
+
 	<country-budget-items vocabulary="2">
 		<budget-item code="1.1.1">
 			<description>
 				<narrative>Description text</narrative>
-			</description> 
+			</description>
 		</budget-item>
 	</country-budget-items>
 

--- a/en/activity-standard/iati-activities/iati-activity/country-budget-items/budget-item.rst
+++ b/en/activity-standard/iati-activities/iati-activity/country-budget-items/budget-item.rst
@@ -5,8 +5,7 @@ Example ``budget-item`` within ``country-budget-items`` of an ``iati-activity``.
 | The ``@code`` attribute declares a valid code (*1.1.1*) from the *BudgetIdentifier* codelist.
 
 .. code-block:: xml
-	:emphasize-lines: 2, 6
-	
+
 	<country-budget-items vocabulary="2">
 		<budget-item code="1.1.1">
 			<description>
@@ -15,14 +14,13 @@ Example ``budget-item`` within ``country-budget-items`` of an ``iati-activity``.
 		</budget-item>
 	</country-budget-items>
 
-| The ``budget-item`` element can be repeated in any ``country-budget-items`` of the same ``vocabulary``.  
+| The ``budget-item`` element can be repeated in any ``country-budget-items`` of the same ``vocabulary``.
 | When multiple ``budget-item`` elements are declared within a single ``country-budget-items`` element, then, for each ``vocabulary`` used, the ``percentage`` values should sum 100%:
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--country-budget-items starts-->
 	:end-before: <!--country-budget-items ends-->
-	:emphasize-lines: 2, 6, 7, 12
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/description.rst
@@ -6,8 +6,7 @@ Example usage of ``description`` of ``budget-item`` element, a child element of 
 	:language: xml
 	:start-after: <!--country-budget-items starts-->
 	:end-before: <!--country-budget-items ends-->
-	:emphasize-lines: 3, 5, 8, 10
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/country-budget-items/budget-item/description/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``descri
 	:language: xml
 	:start-after: <!--country-budget-items starts-->
 	:end-before: <!--country-budget-items ends-->
-	:emphasize-lines: 4, 9 	
-	
+
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/crs-add.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add.rst
@@ -9,14 +9,13 @@ Example ``crs-add`` for an ``iati-activity``.
      <crs-add attached="1">
      ...
      </crs-add>
-     
-| Full example with all child elements: 
+
+| Full example with all child elements:
 
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 1, 17
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/channel-code.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/channel-code.rst
@@ -8,7 +8,6 @@ Example usage of ``channel-code`` of ``crs-add`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 16
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status.rst
@@ -16,7 +16,6 @@ Example usage of ``loan-status`` in context of ``crs-add`` element.
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 10, 15
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/interest-arrears.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/interest-arrears.rst
@@ -6,7 +6,6 @@ Example usage of ``interest-arrears`` within ``loan-status`` in context of ``crs
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 14
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/interest-received.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/interest-received.rst
@@ -6,7 +6,6 @@ Example usage of ``interest-received`` within ``loan-status`` in context of ``cr
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 11
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/principal-arrears.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/principal-arrears.rst
@@ -6,7 +6,6 @@ Example usage of ``principle-arrears`` within ``loan-status`` in context of ``cr
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 13
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/principal-outstanding.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-status/principal-outstanding.rst
@@ -6,7 +6,6 @@ Example usage of ``principle-outstanding`` within ``loan-status`` in context of 
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 12
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms.rst
@@ -11,7 +11,6 @@ The ``loan-terms`` element acts as a container for other elements.
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 3, 9
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/commitment-date.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/commitment-date.rst
@@ -9,7 +9,6 @@ Example usage of ``commitment-date`` within ``loan-terms`` in context of ``crs-a
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 6
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-final-date.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-final-date.rst
@@ -9,7 +9,6 @@ Example usage of ``repayment-final-date`` within ``loan-terms`` in context of ``
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 8
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-first-date.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-first-date.rst
@@ -9,7 +9,6 @@ Example usage of ``repayment-first-date`` within ``loan-terms`` in context of ``
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 7
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-plan.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-plan.rst
@@ -8,7 +8,6 @@ Example usage of ``repayment-plan`` within ``loan-terms`` in context of ``crs-ad
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 5
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-type.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/loan-terms/repayment-type.rst
@@ -8,7 +8,6 @@ Example usage of ``repayment-type`` within ``loan-terms`` in context of ``crs-ad
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 4
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/crs-add/other-flags.rst
+++ b/en/activity-standard/iati-activities/iati-activity/crs-add/other-flags.rst
@@ -10,7 +10,6 @@ Example usage of ``other-flags`` of ``crs-add`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--crs-add starts-->
 	:end-before: <!--crs-add ends-->
-	:emphasize-lines: 2
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/description.rst
@@ -18,7 +18,6 @@ Example ``description`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--description starts-->
 	:end-before: <!--description ends-->
-	:emphasize-lines: 1, 4, 5, 8, 9, 12
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/description/narrative.rst
@@ -6,17 +6,15 @@ The ``narrative`` child element can be used to declare freetext for the ``descri
 	:language: xml
 	:start-after: <!--description starts-->
 	:end-before: <!--description ends-->
-	:emphasize-lines: 2, 6, 10 	
-	
+
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
-		
+
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--description starts-->
 	:end-before: <!--description ends-->
-	:emphasize-lines: 3, 7, 11
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 2.01

--- a/en/activity-standard/iati-activities/iati-activity/document-link.rst
+++ b/en/activity-standard/iati-activities/iati-activity/document-link.rst
@@ -12,14 +12,13 @@ Example ``document-link`` in an ``iati-activity``.
     ...
     </document-link>
 
-| Full example with all child elements: 
+| Full example with all child elements:
 
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 1, 9
-	
+
 | The ``document-link`` element can be repeated in any ``iati-activity``.
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/document-link/category.rst
+++ b/en/activity-standard/iati-activities/iati-activity/document-link/category.rst
@@ -8,9 +8,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 6
 
-| The ``category`` element can be repeated in any ``document-link``.		
+| The ``category`` element can be repeated in any ``document-link``.
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/document-link/document-date.rst
+++ b/en/activity-standard/iati-activities/iati-activity/document-link/document-date.rst
@@ -12,9 +12,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 8
 
-| The ``document-date`` element should only be used once for each ``document-link`` element.		
+| The ``document-date`` element should only be used once for each ``document-link`` element.
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/document-link/language.rst
+++ b/en/activity-standard/iati-activities/iati-activity/document-link/language.rst
@@ -9,16 +9,14 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 7
 
 | In some cases, a ``document-link`` may be in multiple languages.  This is expressed by repeating the ``language`` element.
 
 .. code-block:: xml
-	:emphasize-lines: 7, 8
-	
+
 	<document-link format="application/vnd.oasis.opendocument.text" url="http:www.example.org/docs/report.odt">
 		<title>
-			<narrative>Project Report 2013</narrative>	   
+			<narrative>Project Report 2013</narrative>
 			<narrative xml:lang="fr">Rapport de projet 2013</narrative>
 		</title>
 		<category code="A01" />

--- a/en/activity-standard/iati-activities/iati-activity/document-link/title.rst
+++ b/en/activity-standard/iati-activities/iati-activity/document-link/title.rst
@@ -6,8 +6,7 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 2, 5
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/document-link/title/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/document-link/title/narrative.rst
@@ -6,18 +6,16 @@ The ``narrative`` child element can be used to declare freetext for the ``title`
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 3
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.
 
 | Note: This relates to the language of the text in the XML.
-		
+
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 4
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/fss.rst
+++ b/en/activity-standard/iati-activities/iati-activity/fss.rst
@@ -12,8 +12,7 @@ Example of ``fss`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--fss starts-->
 	:end-before: <!--fss ends-->
-	:emphasize-lines: 1, 3
-      
+
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/fss/forecast.rst
+++ b/en/activity-standard/iati-activities/iati-activity/fss/forecast.rst
@@ -14,7 +14,6 @@ Example of ``forecast`` for the ``fss`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--fss starts-->
 	:end-before: <!--fss ends-->
-	:emphasize-lines: 2
 
 | Note: multiple forecasts are expressed by repeating the ``forecast`` element.
 

--- a/en/activity-standard/iati-activities/iati-activity/humanitarian-scope.rst
+++ b/en/activity-standard/iati-activities/iati-activity/humanitarian-scope.rst
@@ -5,7 +5,7 @@ Example ``humanitarian-scope`` of an ``iati-activity``.
 | The ``@type`` attribute declares a valid code (*1*) from the *HumanitarianScopeType* codelist.
 | The ``@vocabulary`` attribute declares a valid code (*1-2*) from the *HumanitarianScopeVocabulary* codelist.
 | The ``@code`` attribute declares a valid code (*EQ-2015-000048-NPL*) from the specified vocabulary.
- 
+
 .. code-block:: xml
 
 	<humanitarian-scope type="1" vocabulary="1-2" code="EQ-2015-000048-NPL">
@@ -21,15 +21,14 @@ If a publisher uses a vocabulary of 99 (i.e. 'Reporting Organisation'), then the
 	</humanitarian-scope>
 
 
-| The ``humanitarian-scope`` element can be repeated in any ``iati-activity``.  
+| The ``humanitarian-scope`` element can be repeated in any ``iati-activity``.
 
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--humanitarian-scope starts-->
 	:end-before: <!--humanitarian-scope ends-->
-	:emphasize-lines: 1, 2, 4
 
-| If a vocabulary is not on the *HumanitarianScopeVocabulary* codelist, then the value of *99* (*Reporting Organisation*) should be declared.	
+| If a vocabulary is not on the *HumanitarianScopeVocabulary* codelist, then the value of *99* (*Reporting Organisation*) should be declared.
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/humanitarian-scope/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/humanitarian-scope/narrative.rst
@@ -5,14 +5,13 @@ The ``narrative`` child element can be used to declare freetext for the ``humani
 | The ``narrative`` element should be used only when the *99* (*Reporting Organisation*) *HumanitarianScopeVocabulary* is declared.
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<humanitarian-scope type="1" vocabulary="99" vocabulary-uri="http://example.com/vocab.html" code="5">
 	  <narrative>Nepal Earthquake (April 2015)</narrative>
 	</humanitarian-scope>
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/location.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location.rst
@@ -12,13 +12,12 @@ Example ``location`` for an ``iati-activity``.
 	...
 	</location>
 
-| Full example with all child elements:    
-    
+| Full example with all child elements:
+
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location-single ends-->
-	:emphasize-lines: 1, 20
 
 | The ``location`` element can be repeated in any ``iati-activity``:
 
@@ -35,15 +34,15 @@ Changelog
 ~~~~~~~~~
 2.01
 ^^^^
-The following child elements were removed: `coordinates; gazetteer-entry; location-type <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#location-removed-elements>`__. 
+The following child elements were removed: `coordinates; gazetteer-entry; location-type <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#location-removed-elements>`__.
 
-The @percentage attribute was `removed <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#location-removed-attributes>`__. 
+The @percentage attribute was `removed <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#location-removed-attributes>`__.
 
 1.04
 ^^^^
-Note that major changes were made to the subelements of ``location`` in version 1.04.  
+Note that major changes were made to the subelements of ``location`` in version 1.04.
 
-| For more information refer to: 
+| For more information refer to:
 
 * the :doc:`1.04 location changes overview guidance </upgrades/decimal-upgrade-to-1-04/location-summary/>`
 * the :ref:`Activities Schema Changelog <1_04_activities_schema_changes>` (or the individual subemelement pages)

--- a/en/activity-standard/iati-activities/iati-activity/location/activity-description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/activity-description.rst
@@ -6,8 +6,7 @@ Example usage of ``activity-description`` within a ``location`` of an ``iati-act
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 10, 12
-	
+
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/location/activity-description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/activity-description/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` element can be used to declare freetext for the ``activity-des
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 8
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/location/administrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/administrative.rst
@@ -4,18 +4,16 @@ Example usage of ``administrative`` within a ``location`` of an ``iati-activity`
 
 | The ``@vocabulary`` attribute declares a valid code (*G1*) from the *GeographicVocabulary* codelist.
 | An example value of *1453782* from that vocabulary is declared in the ``@code`` attribute.
-| An example value of *1* is declared for the ``@level`` attribute. 
+| An example value of *1* is declared for the ``@level`` attribute.
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 13
 
 Note: Multiple administrative levels can be reported by repeating the ``administrative`` element:
 
 .. code-block:: xml
-	:emphasize-lines: 6, 7
 
 	<location ref="AF-KAN">
 	   <location-id vocabulary="G1" code="1453782" />
@@ -40,7 +38,7 @@ Changelog
 ^^^^
 Freetext is `no longer allowed <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#freetext-amended-elements>`__  within this element.
 
-The @county, @adm1 and @adm2 attributes were `removed <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#location-removed-attributes>`__. 
+The @county, @adm1 and @adm2 attributes were `removed <http://iatistandard.org/upgrades/integer-upgrade-to-2-01/2-01-changes/#location-removed-attributes>`__.
 
 1.04
 ^^^^

--- a/en/activity-standard/iati-activities/iati-activity/location/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/description.rst
@@ -6,7 +6,6 @@ Example usage of ``description`` within a ``location`` of an ``iati-activity``.:
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 7, 9
 
 Changelog
 ~~~~~~~~~
@@ -17,4 +16,4 @@ Freetext is no longer allowed with this element.  It should `now be declared <ht
 
 1.04
 ^^^^
-The documentation in the schema has changed from "A human-readable description of the location (not the activity)." 
+The documentation in the schema has changed from "A human-readable description of the location (not the activity)."

--- a/en/activity-standard/iati-activities/iati-activity/location/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/description/narrative.rst
@@ -6,6 +6,5 @@ The ``narrative`` element can be used to declare freetext for the ``description`
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 8
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``xml:lang`` attribute.  Example not shown.

--- a/en/activity-standard/iati-activities/iati-activity/location/exactness.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/exactness.rst
@@ -8,7 +8,6 @@ Example usage of ``exactness`` within a ``location`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 17
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/location/feature-designation.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/feature-designation.rst
@@ -8,7 +8,6 @@ Example usage of ``feature-designation`` within a ``location`` of an ``iati-acti
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 19
 
 
 

--- a/en/activity-standard/iati-activities/iati-activity/location/location-class.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/location-class.rst
@@ -8,7 +8,6 @@ Example usage of ``location-class`` within a ``location`` of an ``iati-activity`
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 18
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/location/location-id.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/location-id.rst
@@ -9,11 +9,10 @@ Example usage of ``location-id`` within a ``location`` of an ``iati-activity``..
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 3
-	
+
 Note: If the *GeographicVocabulary* *G2* (*Open Street Map*) is used, then the ``@code`` value should be of the form <OSM element>/<OSM identifier>
 
-The OSM element will be a node, way or relation. 
+The OSM element will be a node, way or relation.
 
 | Examples:
 

--- a/en/activity-standard/iati-activities/iati-activity/location/location-reach.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/location-reach.rst
@@ -8,7 +8,6 @@ Example usage of ``location-reach`` within a ``location`` of an ``iati-activity`
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 2
 
 
 

--- a/en/activity-standard/iati-activities/iati-activity/location/name.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/name.rst
@@ -6,8 +6,7 @@ Example usage of ``name`` within a ``location`` of an ``iati-activity``.:
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 4, 6
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/location/name/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/name/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` element can be used to declare freetext for the ``name`` child
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 5
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/location/point.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/point.rst
@@ -8,7 +8,6 @@ Example usage of ``point`` within a ``location`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 14, 16
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/location/point/pos.rst
+++ b/en/activity-standard/iati-activities/iati-activity/location/point/pos.rst
@@ -6,7 +6,6 @@ Example usage of ``pos``, a child element of the ``point`` element of ``location
 	:language: xml
 	:start-after: <!--location-single starts-->
 	:end-before: <!--location ends-->
-	:emphasize-lines: 15
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/other-identifier.rst
+++ b/en/activity-standard/iati-activities/iati-activity/other-identifier.rst
@@ -4,12 +4,11 @@ Example ``other-identifier`` of an ``iati-activity``.
 
 | An example ``@ref`` of *ABC123-XYZ* is declared.
 | The ``@type`` attribute declares a valid code (*A1*) from the *OtherIdentifierType* codelist.
- 
+
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--other-identifier starts-->
 	:end-before: <!--other-identifier ends-->
-	:emphasize-lines: 1, 5	
 
 2.01
 ^^^^

--- a/en/activity-standard/iati-activities/iati-activity/other-identifier/owner-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/other-identifier/owner-org.rst
@@ -8,8 +8,7 @@ Example ``owner-org`` of an ``other-identifier`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--other-identifier starts-->
 	:end-before: <!--other-identifier ends-->
-	:emphasize-lines: 2, 4
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/other-identifier/owner-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/other-identifier/owner-org/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``owner-
 	:language: xml
 	:start-after: <!--other-identifier starts-->
 	:end-before: <!--other-identifier ends-->
-	:emphasize-lines: 3
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/participating-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/participating-org.rst
@@ -8,14 +8,13 @@ Example ``participating-org`` in an ``iati-activity``.
 | The ``@activity-id`` attribute declares an IATI activity identifier.
 
 .. code-block:: xml
-	:emphasize-lines: 1, 3
-	
+
 	<participating-org ref="BB-BBB-123456789" role="2" type="40" activity-id="BB-BBB-123456789-1234">
 		<narrative>Name of Agency B</narrative>
 	</participating-org>
 
 As demonstrated in the the above example, it is strongly recommended that the name of the organisation is provided (using the narrative child element) in addition to a valid organisation identifier. Where an organisation identifier is not present the name (using the narrative child element) is mandatory.
-	
+
 | The ``participating-org`` element can be repeated in any ``iati-activity``.
 | In this example, three ``participating-org`` are declared.
 
@@ -23,7 +22,6 @@ As demonstrated in the the above example, it is strongly recommended that the na
 	:language: xml
 	:start-after: <!--participating-org starts-->
 	:end-before: <!--participating-org ends-->
-	:emphasize-lines: 1, 3, 4, 6, 7, 10		
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/participating-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/participating-org/narrative.rst
@@ -6,18 +6,16 @@ The ``narrative`` child element can be used to declare freetext for the ``partic
 	:language: xml
 	:start-after: <!--participating-org starts-->
 	:end-before: <!--participating-org ends-->
-	:emphasize-lines: 2, 5, 8	
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.
 
 | One example illustrated below:
-		
+
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--participating-org starts-->
 	:end-before: <!--participating-org ends-->
-	:emphasize-lines: 9
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement.rst
@@ -21,7 +21,7 @@ Example ``planned-disbursement`` for an ``iati-activity``.
 	<planned-disbursement type="1">
 	...
 	</planned-disbursement>
-	
+
 | Note: If omitted, then *BudgetType* code *1* (Original) is assumed.
 
 | Full example with all child elements:
@@ -30,9 +30,8 @@ Example ``planned-disbursement`` for an ``iati-activity``.
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 1, 11
-	
-| Note: multiple planned disbursements are expressed by repeating the ``planned-disbursement`` element.	
+
+| Note: multiple planned disbursements are expressed by repeating the ``planned-disbursement`` element.
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/period-end.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/period-end.rst
@@ -15,12 +15,11 @@ Example usage of ``period-end`` of ``planned-disbursement`` for an ``iati-activi
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 3
-	
+
 | In some instances, it may not be feasible to declare an ``period-end`` date.  In such cases, the element is not included:
 
 .. code-block:: xml
-	
+
 	<planned-disbursement type="1">
 		<period-start iso-date="2014-01-01" />
 		<value currency="EUR" value-date="2014-01-01">3000</value>

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/period-start.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/period-start.rst
@@ -15,7 +15,6 @@ Example usage of ``period-start`` of ``planned-disbursement`` for an ``iati-acti
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 2
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/provider-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/provider-org.rst
@@ -14,14 +14,13 @@ Example usage of ``provider-org`` of a ``planned-disbursement`` in an ``iati-act
 .. code-block:: xml
 
         <provider-org ref="BB-BBB-123456789" type="10" provider-activity-id="BB-BBB-123456789-1234AA" />
-        
+
 Full example, within a ``planned-disbursement``.
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 5, 7 
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/provider-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/provider-org/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``provid
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 6	
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/receiver-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/receiver-org.rst
@@ -21,7 +21,6 @@ Full example, within a ``planned-disbursement``.
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 8, 10
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/receiver-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/receiver-org/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``receiv
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 9	
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/planned-disbursement/value.rst
+++ b/en/activity-standard/iati-activities/iati-activity/planned-disbursement/value.rst
@@ -12,7 +12,6 @@ Example usage of ``value`` in context of ``planned-disbursement`` element.
 	:language: xml
 	:start-after: <!--planned-disbursement starts-->
 	:end-before: <!--planned-disbursement ends-->
-	:emphasize-lines: 4
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/policy-marker/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/policy-marker/narrative.rst
@@ -5,14 +5,13 @@ The ``narrative`` child element can be used to declare freetext for the ``policy
 | The ``narrative`` element should be used only when the *99* (*Reporting Organisation*) *PolicyMarkerVocabulary* is declared.
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<policy-marker vocabulary="99" code="10" significance="3">
 		<narrative>Policy Marker Text</narrative>
 	</policy-marker>
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/recipient-country/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/recipient-country/narrative.rst
@@ -5,12 +5,11 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 | Note: Both the ``recipient-region`` and ``recipient-country`` elements still allow both a ``@code`` and descriptive text to be specified. This is to cover the isolated cases where the organisation publishing the data may not agree with name of a country or region given by the lookup codelists IATI uses.  Example in the case of a ``recipient-country`` element:
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<recipient-country code="57" vocabulary="1">
 		<narrative>Kosovo (As per UNSCR 1244)<narrative>
-	</recipient-country>   
-    
+	</recipient-country>
+
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/recipient-region/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/recipient-region/narrative.rst
@@ -5,8 +5,7 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 | Note: Both the ``recipient-region`` and ``recipient-country`` elements still allow both a ``@code`` and descriptive text to be specified. This is to cover the isolated cases where the organisation publishing the data may not agree with name of a country or region given by the lookup codelists IATI uses.  Example in the case of a ``recipient-region`` element:
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<recipient-region code="589" vocabulary="1">
 		<narrative>Middle East, regional (As per WHO Eastern Mediterranean Region)<narrative>
 	</recipient-region>

--- a/en/activity-standard/iati-activities/iati-activity/reporting-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/reporting-org.rst
@@ -10,7 +10,6 @@ Example ``reporting-org`` for an ``iati-activity``
 	:language: xml
 	:start-after: <!--reporting-org starts-->
 	:end-before: <!--reporting-org ends-->
-	:emphasize-lines: 1, 4	        
 
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/reporting-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/reporting-org/narrative.rst
@@ -6,16 +6,14 @@ The ``narrative`` child element can be used to declare freetext for the ``report
 	:language: xml
 	:start-after: <!--reporting-org starts-->
 	:end-before: <!--reporting-org ends-->
-	:emphasize-lines: 2	
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``xml:lang`` attribute:
-		
+
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--reporting-org starts-->
 	:end-before: <!--reporting-org ends-->
-	:emphasize-lines: 3
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result.rst
@@ -14,12 +14,11 @@ Example ``result`` for an ``iati-activity``.
         </result>
 
 | Full example with all child elements:
- 
+
 .. literalinclude:: ../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 1, 46
 
 | The ``result`` element can be repeated in any ``iati-activity``.
 

--- a/en/activity-standard/iati-activities/iati-activity/result/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/description.rst
@@ -6,7 +6,6 @@ Example usage of ``description`` in a ``result`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 5, 7
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/description/narrative.rst
@@ -3,24 +3,22 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``description`` of a ``result``.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<description>
 			<narrative>Result description text</narrative>
-			<narrative xml:lang="fr">Result texte de description</narrative>      
+			<narrative xml:lang="fr">Result texte de description</narrative>
 		</description>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<description>
 			<narrative>Result description text</narrative>
-			<narrative xml:lang="fr">Result texte de description</narrative>   
+			<narrative xml:lang="fr">Result texte de description</narrative>
 		</description>
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator.rst
@@ -2,7 +2,7 @@ Example Usage
 ~~~~~~~~~~~~~
 Example usage of ``indicator``  in a ``result`` of an ``iati-activity``.
 
-| This element is a parent for other child elements.  It is also contained within a ``result`` element.  
+| This element is a parent for other child elements.  It is also contained within a ``result`` element.
 
 | The ``@measure`` attribute declares a valid code (*1*) from the *IndicatorMeasure* codelist.
 | The ``@ascending`` boolean of *1* also declares that the data is asscending.
@@ -11,6 +11,5 @@ Example usage of ``indicator``  in a ``result`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 8, 45
-		
+
 | The ``indicator`` element can be repeated in any ``result`` of an ``iati-activity``.

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline.rst
@@ -8,4 +8,4 @@ Example of ``baseline`` in context of an ``indicator`` in a ``result`` element.
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 18, 22
+

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/comment.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/comment.rst
@@ -6,7 +6,6 @@ Example usage of ``comment`` for ``baseline``:
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 19, 21
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/comment/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/comment/narrative.rst
@@ -3,24 +3,22 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``comment`` of a ``baseline``.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<comment>
 			<narrative>Baseline comment text</narrative>
-			<narrative xml:lang="fr">Baseline comment texte</narrative>      
+			<narrative xml:lang="fr">Baseline comment texte</narrative>
 		</comment>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<comment>
 			<narrative>Baseline comment text</narrative>
-			<narrative xml:lang="fr">Baseline comment texte</narrative>      
+			<narrative xml:lang="fr">Baseline comment texte</narrative>
 		</comment>
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/description.rst
@@ -6,7 +6,6 @@ Example usage of ``description`` in context of an ``indicator`` in a ``result`` 
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 12, 14
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/description/narrative.rst
@@ -3,24 +3,22 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``description`` of a ``result``.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<description>
 			<narrative>Indicator title</narrative>
-			<narrative xml:lang="fr">Indicator titre</narrative>      
+			<narrative xml:lang="fr">Indicator titre</narrative>
 		</description>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<description>
 			<narrative>Indicator title</narrative>
-			<narrative xml:lang="fr">Indicator titre</narrative>      
+			<narrative xml:lang="fr">Indicator titre</narrative>
 		</description>
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period.rst
@@ -2,11 +2,10 @@ Example Usage
 ~~~~~~~~~~~~~
 Example usage of ``period`` in context of an ``indicator`` in a ``result`` element.
 
-| This element is a parent for other child elements. 
+| This element is a parent for other child elements.
 
 .. literalinclude:: ../../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 23, 44
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual.rst
@@ -8,5 +8,4 @@ Example usage of ``actual`` within ``period``, in context of an ``indicator`` in
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 35, 43
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/comment.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/comment.rst
@@ -6,7 +6,6 @@ Example usage of ``comment`` for ``actual``:
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 40, 42
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/comment/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/comment/narrative.rst
@@ -3,24 +3,22 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``comment`` of a ``actual``.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<comment>
 			<narrative>Actual comment text</narrative>
-			<narrative xml:lang="fr">Actual comment texte</narrative>      
+			<narrative xml:lang="fr">Actual comment texte</narrative>
 		</comment>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<comment>
 			<narrative>Actual comment text</narrative>
-			<narrative xml:lang="fr">Actual comment texte</narrative>      
+			<narrative xml:lang="fr">Actual comment texte</narrative>
 		</comment>
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/dimension.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/dimension.rst
@@ -3,6 +3,7 @@ Example Usage
 Example of ``dimension`` in context of an ``actual`` element (as part of a parent ``result``/``indicator`` element).
 
 | This example declares ``@name`` as *sex*, with a ``@value`` of *female*:
+
 .. code-block:: xml
 
     <dimension name="sex" value="female" />
@@ -14,7 +15,6 @@ Example of ``dimension`` in context of an ``actual`` element (as part of a paren
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 38, 39
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/location.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/actual/location.rst
@@ -3,6 +3,7 @@ Example Usage
 Example of ``location`` in context of an ``actual`` element (as part of a parent ``result``/``indicator`` element).
 
 | This example declares ``@ref`` as *AF-KAN*, which matches the ``@ref`` value for a location already referenced in iati-activity/location:
+
 .. code-block:: xml
 
     <location ref="AF-KAN" />
@@ -14,7 +15,6 @@ Example of ``location`` in context of an ``actual`` element (as part of a parent
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 36, 37
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/period-end.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/period-end.rst
@@ -9,5 +9,4 @@ Example usage of ``period-end`` within ``period``, in context of an ``indicator`
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 25
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/period-start.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/period-start.rst
@@ -9,4 +9,4 @@ Example usage of ``period-start`` within ``period``, in context of an ``indicato
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 24
+

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target.rst
@@ -8,4 +8,4 @@ Example usage of ``target`` within ``period``, in context of an ``indicator`` in
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 26, 34
+

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/comment.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/comment.rst
@@ -6,7 +6,6 @@ Example usage of ``comment`` for ``target``:
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 31, 33
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/comment/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/comment/narrative.rst
@@ -3,24 +3,22 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``comment`` of a ``target``.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<comment>
 			<narrative>Target comment text</narrative>
-			<narrative xml:lang="fr">Target comment texte</narrative>      
+			<narrative xml:lang="fr">Target comment texte</narrative>
 		</comment>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<comment>
 			<narrative>Target comment text</narrative>
-			<narrative xml:lang="fr">Target comment texte</narrative>      
+			<narrative xml:lang="fr">Target comment texte</narrative>
 		</comment>
-	
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/dimension.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/dimension.rst
@@ -3,6 +3,7 @@ Example Usage
 Example of ``dimension`` in context of an ``target`` element (as part of a parent ``result``/``indicator`` element).
 
 | This example declares ``@name`` as *sex*, with a ``@value`` of *female*:
+
 .. code-block:: xml
 
     <dimension name="sex" value="female" />
@@ -14,7 +15,6 @@ Example of ``dimension`` in context of an ``target`` element (as part of a paren
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 29, 30
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/location.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/location.rst
@@ -14,7 +14,6 @@ Example of ``location`` in context of an ``target`` element (as part of a parent
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 27, 28
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/reference.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/reference.rst
@@ -22,7 +22,6 @@ If a publisher uses a vocabulary of 99 (i.e. 'Reporting Organisation'), then the
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 15, 16, 17
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/title.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/title.rst
@@ -6,7 +6,6 @@ Example usage of ``title`` in context of an ``indicator`` in a ``result`` elemen
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 9, 11
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/title/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/title/narrative.rst
@@ -3,23 +3,21 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``title`` parent element.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<title>
 			<narrative>Indicator title</narrative>
-			<narrative xml:lang="fr">Indicator titre</narrative>      
+			<narrative xml:lang="fr">Indicator titre</narrative>
 		</title>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<title>
 			<narrative>Indicator title</narrative>
-			<narrative xml:lang="fr">Indicator titre</narrative>      
+			<narrative xml:lang="fr">Indicator titre</narrative>
 		</title>
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/result/title.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/title.rst
@@ -6,7 +6,6 @@ Example usage of ``title`` in a ``result`` of an ``iati-activity``.
 	:language: xml
 	:start-after: <!--result starts-->
 	:end-before: <!--result ends-->
-	:emphasize-lines: 2, 4
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/result/title/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/title/narrative.rst
@@ -3,23 +3,21 @@ Example Usage
 The ``narrative`` child element can be used to declare freetext for the ``title`` parent element.
 
 .. code-block:: xml
-	:emphasize-lines: 2	
-	
+
 		<title>
 			<narrative>Result title</narrative>
-			<narrative xml:lang="fr">Result titre</narrative>      
+			<narrative xml:lang="fr">Result titre</narrative>
 		</title>
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
 
 .. code-block:: xml
-	:emphasize-lines: 3	
-	
+
 		<title>
 			<narrative>Result title</narrative>
-			<narrative xml:lang="fr">Result titre</narrative>      
+			<narrative xml:lang="fr">Result titre</narrative>
 		</title>
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/sector/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/sector/narrative.rst
@@ -5,14 +5,13 @@ The ``narrative`` child element can be used to declare freetext for the ``sector
 | The ``narrative`` element should be used specially when the *99* (Reporting Organisation) or *98* (Reporting Organisation 2) *SectorVocabulary* are declared.
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<sector vocabulary="99" code="1">
 		<narrative>Health Sector</narrative>
 	</sector>
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/title.rst
+++ b/en/activity-standard/iati-activities/iati-activity/title.rst
@@ -6,8 +6,7 @@ Example ``title`` for an ``iati-activity``:
 	:language: xml
 	:start-after: <!--title starts-->
 	:end-before: <!--title ends-->
-	:emphasize-lines: 1, 5	
-	  
+
 Changelog
 ~~~~~~~~~
 2.01

--- a/en/activity-standard/iati-activities/iati-activity/title/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/title/narrative.rst
@@ -6,18 +6,16 @@ The ``narrative`` child element can be used to declare freetext for the ``title`
 	:language: xml
 	:start-after: <!--title starts-->
 	:end-before: <!--title ends-->
-	:emphasize-lines: 2	
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute:
-		
+
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--title starts-->
 	:end-before: <!--title ends-->
-	:emphasize-lines: 3, 4
-	
-Note: It is recommended to provide a ``title`` in the language(s) spoken in the country(ies) where the ``iati-activity`` take place, or is aimed at.	
-	
+
+Note: It is recommended to provide a ``title`` in the language(s) spoken in the country(ies) where the ``iati-activity`` take place, or is aimed at.
+
 Changelog
 ~~~~~~~~~
 2.01

--- a/en/activity-standard/iati-activities/iati-activity/transaction.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction.rst
@@ -26,9 +26,8 @@ Example ``transaction`` in an ``iati-activity``.
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 1, 23
-	    
-| The ``transaction`` element can be repeated in any ``iati-activity``.  
+
+| The ``transaction`` element can be repeated in any ``iati-activity``.
 
 
 Changelog
@@ -36,4 +35,4 @@ Changelog
 
 2.02
 ^^^^
-| The ``humanitarian`` attribute was `added <http://support.iatistandard.org/entries/106937796-Humanitarian-Flag>`__.    
+| The ``humanitarian`` attribute was `added <http://support.iatistandard.org/entries/106937796-Humanitarian-Flag>`__.

--- a/en/activity-standard/iati-activities/iati-activity/transaction/aid-type.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/aid-type.rst
@@ -4,10 +4,10 @@ Example usage of ``aid-type`` of a ``transaction`` in an ``iati-activity``.
 
 | The ``@code`` attribute declares a valid code (*A02*) from the *AidType* codelist.
 
-| Note: The ``aid-type`` element can override the ``default-aid-type`` value set in ``iati-activity``: 
+| Note: The ``aid-type`` element can override the ``default-aid-type`` value set in ``iati-activity``:
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 21
+

--- a/en/activity-standard/iati-activities/iati-activity/transaction/description.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/description.rst
@@ -6,8 +6,7 @@ Example usage of ``description`` of a ``transaction`` in an ``iati-activity``.
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 5, 7
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/transaction/description/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/description/narrative.rst
@@ -6,10 +6,9 @@ The ``narrative`` child element can be used to declare freetext for the ``descri
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 6
-	
+
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/transaction/disbursement-channel.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/disbursement-channel.rst
@@ -8,7 +8,6 @@ Example usage of ``disbursement-channel`` of a ``transaction`` in an ``iati-acti
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 14
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/finance-type.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/finance-type.rst
@@ -4,13 +4,12 @@ Example usage of ``finance-type`` of a ``transaction`` in an ``iati-activity``.
 
 | The ``@code`` attribute declares a valid code (*111*) from the *FinanceType* codelist.
 
-| Note: The ``finance-type`` element can override the ``default-finance-type`` value set in ``iati-activity``: 
+| Note: The ``finance-type`` element can override the ``default-finance-type`` value set in ``iati-activity``:
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 20
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/flow-type.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/flow-type.rst
@@ -4,13 +4,12 @@ Example usage of ``flow-type`` of a ``transaction`` in an ``iati-activity``.
 
 | The ``@code`` attribute declares a valid code (*20*) from the *FlowType* codelist.
 
-| Note: The ``flow-type`` element can override the ``default-flow-type`` value set in ``iati-activity``: 
+| Note: The ``flow-type`` element can override the ``default-flow-type`` value set in ``iati-activity``:
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 19
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/provider-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/provider-org.rst
@@ -19,14 +19,13 @@ Example usage of ``provider-org`` of a ``transaction`` in an ``iati-activity``.
           <narrative>Agency B</narrative>
         </provider-org>
 
-        
+
 Full example, within a ``transaction``.
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 8, 10 
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/provider-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/provider-org/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``provid
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 9	
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/transaction/receiver-org.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/receiver-org.rst
@@ -25,7 +25,6 @@ Full example, within a ``transaction``.
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 11, 13
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/receiver-org/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/receiver-org/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``receiv
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 12	
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/activity-standard/iati-activities/iati-activity/transaction/recipient-country.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/recipient-country.rst
@@ -14,8 +14,7 @@ Full example:
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 17
- 
+
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/recipient-country/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/recipient-country/narrative.rst
@@ -5,12 +5,11 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 | Note: Both the ``recipient-region`` and ``recipient-country`` elements still allow both a ``@code`` and descriptive text to be specified. This is to cover the isolated cases where the organisation publishing the data may not agree with name of a country or region given by the lookup codelists IATI uses.
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<recipient-country code="XK">
 		<narrative>Kosovo (As per UNSCR 1244)<narrative>
-	</recipient-country>   
-    
+	</recipient-country>
+
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
 
 Changelog

--- a/en/activity-standard/iati-activities/iati-activity/transaction/recipient-region.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/recipient-region.rst
@@ -1,6 +1,6 @@
 Example Usage
 ~~~~~~~~~~~~~
-Example ``recipient-region`` of an ``iati-activity``. 
+Example ``recipient-region`` of an ``iati-activity``.
 
 | The ``@code`` attribute declares a valid code (*489*) from the *Region* codelist.
 | The optional ``@vocabulary`` attribute declares a valid code (*1*) from the *RegionVocabulary* codelist.
@@ -10,6 +10,7 @@ Example ``recipient-region`` of an ``iati-activity``.
 	<recipient-region code="489" vocabulary="1" />
 
 If a publisher uses a vocabulary of 99 (i.e. 'Reporting Organisation'), then the ``@vocabulary-uri`` attribute should also be used, for example:
+
 .. code-block:: xml
 
 	<recipient-region code="A1" vocabulary="99" vocabulary-uri="http://example.com/vocab.html" />
@@ -20,7 +21,6 @@ Full example:
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 18
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/sector.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/sector.rst
@@ -8,14 +8,15 @@ Example ``sector`` of a ``transaction`` within an ``iati-activity``.
 .. code-block:: xml
 
 	<sector vocabulary="2" code="111" />
-        
-| The ``sector`` element can be repeated in any ``transaction``. 
-  
+
+| The ``sector`` element can be repeated in any ``transaction``.
+
 | The ``vocabulary`` is used to declare which ``SectorVocabulary`` classification list is in use. If this is omitted, then IATI assumes a *SectorVocabulary* of *1* (OECD DAC CRS Purpose Codes (5 digit)).
 
 | If a vocabulary is not on the *SectorVocabulary* codelist, then the value of *99* or *98* (Reporting Organisation) should be declared.
 
 | If a publisher uses a vocabulary of 98 or 99 (i.e. 'Reporting Organisation'), then the ``@vocabulary-uri`` attribute should also be used, for example:
+
 .. code-block:: xml
 
     <sector vocabulary="99" vocabulary-uri="http://example.com/vocab.html" code="A1" />
@@ -26,7 +27,6 @@ Full example:
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 15
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/sector/narrative.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/sector/narrative.rst
@@ -5,8 +5,7 @@ The ``narrative`` child element can be used to declare freetext for the ``sector
 | The ``narrative`` element should be used specially when the *99* (Reporting Organisation) or *98* (Reporting Organisation 2) *SectorVocabulary* are declared.
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<sector vocabulary="99" code="1">
 		<narrative>Health Sector</narrative>
 	</sector>

--- a/en/activity-standard/iati-activities/iati-activity/transaction/tied-status.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/tied-status.rst
@@ -4,13 +4,12 @@ Example usage of ``tied-status`` of a ``transaction`` in an ``iati-activity``.
 
 | The ``@code`` attribute declares a valid code (*5*) from the *TiedStatus* codelist.
 
-| Note: The ``tied-status`` element can override the ``default-tied-status`` value set in ``iati-activity``: 
+| Note: The ``tied-status`` element can override the ``default-tied-status`` value set in ``iati-activity``:
 
 .. literalinclude:: ../../../activity-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 22
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/transaction-date.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/transaction-date.rst
@@ -9,4 +9,4 @@ Example usage of ``transaction-date`` of a ``transaction`` in an ``iati-activity
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 3
+

--- a/en/activity-standard/iati-activities/iati-activity/transaction/transaction-type.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/transaction-type.rst
@@ -8,7 +8,6 @@ Example usage of ``transaction-type`` of ``transaction`` for an ``iati-activity`
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 2
 
 Changelog
 ~~~~~~~~~

--- a/en/activity-standard/iati-activities/iati-activity/transaction/value.rst
+++ b/en/activity-standard/iati-activities/iati-activity/transaction/value.rst
@@ -12,8 +12,7 @@ Example usage of ``value`` of a ``transaction`` in an ``iati-activity``.
 	:language: xml
 	:start-after: <!--transaction starts-->
 	:end-before: <!--transaction ends-->
-	:emphasize-lines: 4
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link.rst
@@ -18,10 +18,9 @@ Example ``document-link`` in an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 1, 9
 
 | The ``document-link`` element can be repeated in any ``iati-organisation``.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/category.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/category.rst
@@ -8,16 +8,14 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 5
 
-| The ``category`` element can be repeated in any ``document-link``.	
+| The ``category`` element can be repeated in any ``document-link``.
 | Example declaring multiple ``DocumentCategory`` codes for the same ``document-link``:
 
 .. literalinclude:: ../../../organisation-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--multi-cat-document-link starts-->
 	:end-before: <!--multi-cat-document-link ends-->
-	:emphasize-lines: 6, 7, 8
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/document-date.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/document-date.rst
@@ -12,9 +12,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 7
 
-| The ``document-date`` element should only be used once for each ``document-link`` element.		
+| The ``document-date`` element should only be used once for each ``document-link`` element.
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/language.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/language.rst
@@ -9,23 +9,21 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link-title starts-->
 	:end-before: <!--document-link-title ends-->
-	:emphasize-lines: 7
 
 | In some cases, a ``document-link`` may be in multiple languages.  This is expressed by repeating the ``language`` element.
 
 .. code-block:: xml
-	:emphasize-lines: 7, 8
-	
+
 	<document-link format="application/vnd.oasis.opendocument.text" url="http:www.example.org/docs/report.odt">
 		<title>
-			<narrative>Annual Report 2013</narrative>	   
+			<narrative>Annual Report 2013</narrative>
 			<narrative xml:lang="fr">Rapport annuel 2013</narrative>
 		</title>
 		<category code="B01" />
 		<language code="en" />
 		<language code="fr" />
 	</document-link>
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/recipient-country.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/recipient-country.rst
@@ -8,7 +8,6 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 8
 
 | The ``recipient-country`` element can be repeated in any ``document-link``.
 | Example declaring multiple ``recipient-country`` elements for the same ``document-link``:
@@ -17,9 +16,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--multi-country-document-link starts-->
 	:end-before: <!--multi-country-document-link ends-->
-	:emphasize-lines: 8, 9, 10
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/recipient-country/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/recipient-country/narrative.rst
@@ -5,14 +5,13 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 | Note: Both the ``recipient-region`` and ``recipient-country`` elements still allow both a ``@code`` and descriptive text to be specified. This is to cover the isolated cases where the organisation publishing the data may not agree with name of a country or region given by the lookup codelists IATI uses.
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<recipient-country code="XK">
 		<narrative>Kosovo (As per UNSCR 1244)<narrative>
-	</recipient-country>   
+	</recipient-country>
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/title.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/title.rst
@@ -6,7 +6,6 @@ Example Usage
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 2, 4
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/title/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/title/narrative.rst
@@ -6,18 +6,16 @@ The ``narrative`` child element can be used to declare freetext for the ``title`
 	:language: xml
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
-	:emphasize-lines: 3
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``xml:lang`` attribute.
 
 | Note: This relates to the language of the text in the XML.
-		
+
 .. literalinclude:: ../../../../organisation-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--document-link-title starts-->
 	:end-before: <!--document-link-title ends-->
-	:emphasize-lines: 4
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/name.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/name.rst
@@ -6,8 +6,7 @@ Example of ``name`` of an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--name starts-->
 	:end-before: <!--name ends-->
-	:emphasize-lines: 1, 4	
-		
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/name/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/name/narrative.rst
@@ -6,16 +6,14 @@ The ``narrative`` child element can be used to declare freetext for the ``name``
 	:language: xml
 	:start-after: <!--name starts-->
 	:end-before: <!--name ends-->
-	:emphasize-lines: 2	
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute:
-		
+
 .. literalinclude:: ../../../organisation-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--name starts-->
 	:end-before: <!--name ends-->
-	:emphasize-lines: 3
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget.rst
@@ -16,10 +16,9 @@ Example Usage
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 1, 10
-	
-| The ``recipient-country-budget`` element can be repeated in any ``iati-organisation``. 
-		
+
+| The ``recipient-country-budget`` element can be repeated in any ``iati-organisation``.
+
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/budget-line.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/budget-line.rst
@@ -8,11 +8,10 @@ Example ``budget-line`` for ``recipient-country-budget`` of an ``iati-organisati
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 6, 9
 
-| The ``budget-line`` element can be repeated in any ``recipient-country-budget``. 
+| The ``budget-line`` element can be repeated in any ``recipient-country-budget``.
 
-		
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/budget-line/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/budget-line/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``budget
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 8
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
 
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/budget-line/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/budget-line/value.rst
@@ -12,8 +12,7 @@ Example usage of ``value`` in context of ``budget-line`` element.
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 7
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/period-end.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/period-end.rst
@@ -9,5 +9,4 @@ Example ``period-end`` of ``recipient-country-budget`` for an ``iati-organisatio
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 4
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/period-start.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/period-start.rst
@@ -9,4 +9,4 @@ Example ``period-start`` of ``recipient-country-budget`` for an ``iati-organisat
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 3
+

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/recipient-country.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/recipient-country.rst
@@ -6,7 +6,6 @@ Example usage of ``recipient-country`` in context of ``recipient-country-budget`
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 2
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/recipient-country/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/recipient-country/narrative.rst
@@ -5,14 +5,13 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 | Note: Both the ``recipient-region`` and ``recipient-country`` elements still allow both a ``@code`` and descriptive text to be specified. This is to cover the isolated cases where the organisation publishing the data may not agree with name of a country or region given by the lookup codelists IATI uses. Example in the case of a ``recipient-country`` element:
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<recipient-country code="XK">
 		<narrative>Kosovo (As per UNSCR 1244)<narrative>
-	</recipient-country>   
+	</recipient-country>
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-country-budget/value.rst
@@ -12,8 +12,7 @@ Example ``value`` of ``recipient-country-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--recipient-country-budget starts-->
 	:end-before: <!--recipient-country-budget ends-->
-	:emphasize-lines: 5
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget.rst
@@ -16,9 +16,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 1, 12
 
-| The ``recipient-org-budget`` element can be repeated in any ``iati-organisation``. 
+| The ``recipient-org-budget`` element can be repeated in any ``iati-organisation``.
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/budget-line.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/budget-line.rst
@@ -8,11 +8,10 @@ Example ``budget-line`` for ``recipient-org-budget`` of an ``iati-organisation``
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 8, 11
 
-| The ``budget-line`` element can be repeated in any ``recipient-org-budget``. 
+| The ``budget-line`` element can be repeated in any ``recipient-org-budget``.
 
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/budget-line/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/budget-line/narrative.rst
@@ -6,10 +6,9 @@ The ``narrative`` child element can be used to declare freetext for the ``budget
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 10
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/budget-line/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/budget-line/value.rst
@@ -12,8 +12,7 @@ Example usage of ``value`` in context of ``budget-line`` element.
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 9
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/period-end.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/period-end.rst
@@ -9,4 +9,4 @@ Example ``period-end`` of ``recipient-org-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 6
+

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/period-start.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/period-start.rst
@@ -9,4 +9,4 @@ Example ``period-start`` of ``recipient-org-budget`` for an ``iati-organisation`
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 5
+

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/recipient-org.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/recipient-org.rst
@@ -6,8 +6,7 @@ Example usage of ``recipient-org`` in context of ``recipient-org-budget`` elemen
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 2, 4
-	
+
 Changelog
 ~~~~~~~~~
 2.01

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/recipient-org/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/recipient-org/narrative.rst
@@ -6,11 +6,10 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 3
 
 Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
-		
-	
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-org-budget/value.rst
@@ -12,8 +12,7 @@ Example ``value`` of ``recipient-org-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--recipient-org-budget starts-->
 	:end-before: <!--recipient-org-budget ends-->
-	:emphasize-lines: 7
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget.rst
@@ -16,9 +16,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 1, 10
-	
-| The ``recipient-region-budget`` element can be repeated in any ``iati-organisation``. 
+
+| The ``recipient-region-budget`` element can be repeated in any ``iati-organisation``.
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/budget-line.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/budget-line.rst
@@ -8,11 +8,10 @@ Example ``budget-line`` for ``recipient-region-budget`` of an ``iati-organisatio
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 6, 9
 
-| The ``budget-line`` element can be repeated in any ``recipient-region-budget``. 
+| The ``budget-line`` element can be repeated in any ``recipient-region-budget``.
 
-		
+
 Changelog
 ~~~~~~~~~
 2.02

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/budget-line/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/budget-line/narrative.rst
@@ -6,7 +6,6 @@ The ``narrative`` child element can be used to declare freetext for the ``budget
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 8
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/budget-line/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/budget-line/value.rst
@@ -12,8 +12,7 @@ Example usage of ``value`` in context of ``budget-line`` element.
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 7
-			
+
 Changelog
 ~~~~~~~~~
 2.02

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/period-end.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/period-end.rst
@@ -9,7 +9,6 @@ Example ``period-end`` of ``recipient-region-budget`` for an ``iati-organisation
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 4
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/period-start.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/period-start.rst
@@ -9,7 +9,6 @@ Example ``period-start`` of ``recipient-region-budget`` for an ``iati-organisati
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 3
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/recipient-region.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/recipient-region.rst
@@ -20,7 +20,6 @@ Example of ``recipient-region`` in context of a complete ``recipient-region-budg
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 2
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/recipient-region/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/recipient-region/narrative.rst
@@ -5,14 +5,13 @@ The ``narrative`` child element can be used to declare freetext for the ``recipi
 | Note: Both the ``recipient-region`` and ``recipient-country`` elements still allow both a ``@code`` and descriptive text to be specified. This is to cover the isolated cases where the organisation publishing the data may not agree with name of a country or region given by the lookup codelists IATI uses.  Example in the case of a ``recipient-region`` element:
 
 .. code-block:: xml
-	:emphasize-lines: 2
-	
+
 	<recipient-region code="589" vocabulary="1">
 		<narrative>Middle East, regional (As per WHO Eastern Mediterranean Region)<narrative>
 	</recipient-region>
 
 | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-activity``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/recipient-region-budget/value.rst
@@ -12,8 +12,7 @@ Example ``value`` of ``recipient-region-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--recipient-region-budget starts-->
 	:end-before: <!--recipient-region-budget ends-->
-	:emphasize-lines: 5
-	
+
 Changelog
 ~~~~~~~~~
 2.02

--- a/en/organisation-standard/iati-organisations/iati-organisation/reporting-org.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/reporting-org.rst
@@ -10,9 +10,8 @@ Example ``reporting-org`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--reporting-org starts-->
 	:end-before: <!--reporting-org ends-->
-	:emphasize-lines: 1, 4	
-	
-		
+
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/reporting-org/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/reporting-org/narrative.rst
@@ -6,16 +6,14 @@ The ``narrative`` child element can be used to declare freetext for the ``report
 	:language: xml
 	:start-after: <!--reporting-org starts-->
 	:end-before: <!--reporting-org ends-->
-	:emphasize-lines: 2	
 
 The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute:
-		
+
 .. literalinclude:: ../../../organisation-standard-example-annotated.xml
 	:language: xml
 	:start-after: <!--reporting-org starts-->
 	:end-before: <!--reporting-org ends-->
-	:emphasize-lines: 3
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget.rst
@@ -16,9 +16,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 1, 9
 
-| The ``total-budget`` element can be repeated in any ``iati-organisation``. 
+| The ``total-budget`` element can be repeated in any ``iati-organisation``.
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget/budget-line.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget/budget-line.rst
@@ -8,11 +8,10 @@ Example ``budget-line`` for ``total-budget`` of an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 5, 8
 
-| The ``budget-line`` element can be repeated in any ``total-budget``. 
+| The ``budget-line`` element can be repeated in any ``total-budget``.
 
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget/budget-line/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget/budget-line/narrative.rst
@@ -6,10 +6,9 @@ The ``narrative`` child element can be used to declare freetext for the ``budget
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 7
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget/budget-line/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget/budget-line/value.rst
@@ -12,8 +12,7 @@ Example usage of ``value`` in context of ``budget-line`` element.
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 6
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget/period-end.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget/period-end.rst
@@ -9,4 +9,4 @@ Example ``period-end`` of ``total-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 3
+

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget/period-start.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget/period-start.rst
@@ -9,4 +9,4 @@ Example ``period-start`` of ``total-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 2
+

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-budget/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-budget/value.rst
@@ -12,8 +12,7 @@ Example ``value`` of ``total-budget`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-budget starts-->
 	:end-before: <!--total-budget ends-->
-	:emphasize-lines: 4
-			
+
 Changelog
 ~~~~~~~~~
 

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure.rst
@@ -16,9 +16,8 @@ Example Usage
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 1, 9
 
-| The ``total-expenditure`` element can be repeated in any ``iati-organisation``. 
+| The ``total-expenditure`` element can be repeated in any ``iati-organisation``.
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/expense-line.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/expense-line.rst
@@ -8,11 +8,10 @@ Example ``expense-line`` for ``total-expenditure`` of an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 5, 8
 
-| The ``expense-line`` element can be repeated in any ``total-expenditure``. 
+| The ``expense-line`` element can be repeated in any ``total-expenditure``.
 
-			
+
 Changelog
 ~~~~~~~~~
 2.02

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/expense-line/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/expense-line/narrative.rst
@@ -6,10 +6,9 @@ The ``narrative`` child element can be used to declare freetext for the ``expens
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 7
 
 | Note: The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``@xml:lang`` attribute.  Example not shown.
-	
+
 Changelog
 ~~~~~~~~~
 2.02

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/expense-line/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/expense-line/value.rst
@@ -12,8 +12,7 @@ Example usage of ``value`` in context of ``expense-line`` element.
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 6
-			
+
 Changelog
 ~~~~~~~~~
 2.02

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/period-end.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/period-end.rst
@@ -9,7 +9,6 @@ Example ``period-end`` of ``total-expenditure`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 3
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/period-start.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/period-start.rst
@@ -9,7 +9,6 @@ Example ``period-start`` of ``total-expenditure`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 2
 
 Changelog
 ~~~~~~~~~

--- a/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/value.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/total-expenditure/value.rst
@@ -12,8 +12,7 @@ Example ``value`` of ``total-expenditure`` for an ``iati-organisation``.
 	:language: xml
 	:start-after: <!--total-expenditure starts-->
 	:end-before: <!--total-expenditure ends-->
-	:emphasize-lines: 4
-			
+
 Changelog
 ~~~~~~~~~
 2.02


### PR DESCRIPTION
Highlighting of particular lines in examples is being removed. This is since updating referenced line numbers is not a current priority. It may be re-added in the future, either manually or automatically.

It has been removed from blocks from both included files and page-specific blocks. This is so that consistency is maintained.