### PR TITLE
Change version number in 2.03 example XML

### DIFF
--- a/en/activity-standard/activity-standard-example-annotated.xml
+++ b/en/activity-standard/activity-standard-example-annotated.xml
@@ -2,10 +2,10 @@
 <!--This is example XML for the IATI activity standard.  No reference to actual data, real organisations or development cooperation models is intended.-->
 
 <!--iati-activities starts-->
-<iati-activities generated-datetime="2014-09-10T07:15:37Z" version="2.02" linked-data-default="http://data.example.org/">
+<iati-activities generated-datetime="2018-02-15T10:44:37Z" version="2.03" linked-data-default="http://data.example.org/">
 
  <!--iati-activity starts-->
- <iati-activity xml:lang="en" default-currency="USD" last-updated-datetime="2014-09-10T07:15:37Z" humanitarian="1" linked-data-uri="http://data.example.org/123456789" hierarchy="1" budget-not-provided="1">
+ <iati-activity xml:lang="en" default-currency="USD" last-updated-datetime="2018-02-15T10:44:37Z" humanitarian="1" linked-data-uri="http://data.example.org/123456789" hierarchy="1" budget-not-provided="1">
 
   <!--iati-identifier starts-->
   <iati-identifier>AA-AAA-123456789-ABC123</iati-identifier>


### PR DESCRIPTION
Change 2.03 Example XML Version Number.

The XML is for v2.03. As such, the Version attribute should demonstrate this.

Also change generation date to be a date nearer 2.03 being a thing.