### PR TITLE
Fix some build warnings (v2.03)

### DIFF
--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/dimension.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/dimension.rst
@@ -3,6 +3,7 @@ Example Usage
 Example of ``dimension`` in context of a ``baseline`` element (as part of a parent ``result``/``indicator`` element).
 
 | This example declares ``@name`` as *sex*, with a ``@value`` of *female*:
+
 .. code-block:: xml
 
     <dimension name="sex" value="female" />

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/location.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/baseline/location.rst
@@ -3,6 +3,7 @@ Example Usage
 Example of ``location`` in context of a ``baseline`` element (as part of a parent ``result``/``indicator`` element).
 
 | This example declares ``@ref`` as *AF-KAN*, which matches the ``@ref`` value for a location already referenced in iati-activity/location:
+
 .. code-block:: xml
 
     <location ref="AF-KAN" />

--- a/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/location.rst
+++ b/en/activity-standard/iati-activities/iati-activity/result/indicator/period/target/location.rst
@@ -3,6 +3,7 @@ Example Usage
 Example of ``location`` in context of an ``target`` element (as part of a parent ``result``/``indicator`` element).
 
 | This example declares ``@ref`` as *AF-KAN*, which matches the ``@ref`` value for a location already referenced in iati-activity/location:
+
 .. code-block:: xml
 
     <location ref="AF-KAN" />

--- a/en/activity-standard/iati-activities/iati-activity/sector.rst
+++ b/en/activity-standard/iati-activities/iati-activity/sector.rst
@@ -22,6 +22,7 @@ Example ``sector`` of an ``iati-activity``.
 | If a vocabulary is not on the *SectorVocabulary* codelist, then the value of *99* or *98* (Reporting Organisation) should be declared.
 
 | If a publisher uses a vocabulary of 98 or 99 (i.e. 'Reporting Organisation'), then the ``@vocabulary-uri`` attribute should also be used, for example:
+
 .. code-block:: xml
 
     <sector vocabulary="99" vocabulary-uri="http://example.com/vocab.html" code="A1" />

--- a/en/activity-standard/iati-activities/iati-activity/tag.rst
+++ b/en/activity-standard/iati-activities/iati-activity/tag.rst
@@ -19,6 +19,7 @@ Example ``tag`` in a ``iati-activity`` element.
 | If a vocabulary is not on the *TagVocabulary* codelist, then the value of *99* (Reporting Organisation) should be declared.
 
 | If a publisher uses a vocabulary of 99 (i.e. 'Reporting Organisation'), then the ``@vocabulary-uri`` attribute should also be used, for example:
+
 .. code-block:: xml
 
     <tag vocabulary="99" vocabulary-uri="http://example.com/vocab.html" code="T1" />


### PR DESCRIPTION
This fixes a few build warnings caused by syntax errors.

NB this should be fixed on other branches, too.