### PR TITLE
Fix example usage (addendum to #442) (v2.03)

### DIFF
--- a/en/organisation-standard/iati-organisations/iati-organisation/document-link/description/narrative.rst
+++ b/en/organisation-standard/iati-organisations/iati-organisation/document-link/description/narrative.rst
@@ -7,9 +7,9 @@ The ``narrative`` child element can be used to declare freetext for the ``descri
 	:start-after: <!--document-link starts-->
 	:end-before: <!--document-link ends-->
 
-  | The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``xml:lang`` attribute.
+| The ``narrative`` element can be repeated for any language additional to the default language set in ``iati-organisation``, by using the ``xml:lang`` attribute.
 
-  | Note: This relates to the language of the text in the XML.
+| Note: This relates to the language of the text in the XML.
 
 Changelog
 ~~~~~~~~~


### PR DESCRIPTION
Refs #441.

#442 wasn’t quite correct – some more whitespace needed to be removed to prevent build errors, so that’s done here.

As before, this element is new in v2.03, so this fix doesn’t need to be applied on other branches.