### PR TITLE
Fixed wrong formatting in last para

### DIFF
--- a/en/activity-standard/overview/country-budget-alignment.rst
+++ b/en/activity-standard/overview/country-budget-alignment.rst
@@ -36,5 +36,5 @@ In a fairly broad sample of 35-40 countries, various studies found that more dis
 
 The CRS purpose codes, including the more detailed voluntary codes, are listed in the `DAC and CRS codelists Excel sheet <http://www.oecd.org/dac/financing-sustainable-development/development-finance-standards/DAC-CRS-CODES.xls>`_ .
 
-The additional codes were `approved by WP-STAT under the written procedure <http://www.oecd.org/officialdocuments/publicdisplaydocumentpdf/?cote=DCD/DAC/STAT(2015)30/REV1&docLanguage=En>`_ in February 2016. The `IATI Steering Committee <approved the use of the more detailed CRS purpose codes](http://www.aidtransparency.net/wp-content/uploads/2013/01/Paper-4c-from-TAG-Working-Group-on-Budget-Identifier.pdf>`_ (instead of using the “Common Code" codelist) in March 2014.
+The additional codes were `approved by WP-STAT under the written procedure <http://www.oecd.org/officialdocuments/publicdisplaydocumentpdf/?cote=DCD/DAC/STAT(2015)30/REV1&docLanguage=En>`_ in February 2016. The `IATI Steering Committee approved the use of the more detailed CRS purpose codes <http://www.aidtransparency.net/wp-content/uploads/2013/01/Paper-4c-from-TAG-Working-Group-on-Budget-Identifier.pdf>`_ (instead of using the “Common Code" codelist) in March 2014.
 


### PR DESCRIPTION
The formatting in the last paragraph was wrong- not providing the correct URL link  for 'IATI Steering Committee approved the use of the more detailed CRS purpose codes'.