### PR TITLE
Add a changelog entry for ActivityStatus bugfix (v1.04)

### DIFF
--- a/en/codelists/ActivityStatus.rst
+++ b/en/codelists/ActivityStatus.rst
@@ -1,0 +1,6 @@
+Changelog
+~~~~~~~~~
+
+04/12/2018
+
+The names for *ActivityStatus* codes *3* and *4* were changed for clarity. This was completed as a `bug fix <https://discuss.iatistandard.org/t/activitystatus-codes-mixup-of-descriptions-for-codes-3-4/304/>`__.


### PR DESCRIPTION
As suggested by @stevieflow [here](https://discuss.iatistandard.org/t/implemented-as-bug-fix-activitystatus-codes-mixup-of-descriptions-for-codes-3-4/304/67).

Refs #531.