### PR TITLE
203 remove contents section

### DIFF
--- a/en/activity-standard.rst
+++ b/en/activity-standard.rst
@@ -36,16 +36,5 @@ When declaring information using the **IATI activity standard** the following sh
 * Can any Creditor Reporting System and/or Forward Survey Spending :doc:`data be included </activity-standard/overview/crs-fss/>`?
 * What are the designated :doc:`contact details </activity-standard/overview/contact-info/>` for the activity?
 
-
-Contents
---------
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   activity-standard/overview
-   activity-standard/elements
-
 .. meta::
  :order: 0

--- a/en/organisation-standard.rst
+++ b/en/organisation-standard.rst
@@ -28,16 +28,5 @@ Considerations
 * What are the organisation’s planned future :doc:`budgets </organisation-standard/overview/budgets/>` for aid given to recipient organisations?
 * Where are the organisation’s official public :doc:`documents </organisation-standard/overview/documents/>`?
 
-
-Contents
---------
-
-.. toctree::
-   :titlesonly:
-   :maxdepth: 1
-
-   organisation-standard/overview
-   organisation-standard/elements
-
 .. meta::
   :order: 1


### PR DESCRIPTION
With the wagtail design, the contents section on the activity and organisation pages are no longer needed.

See: https://dev.iatistandard.org/en/iati-standard/203/organisation-standard/