### PR TITLE
Migration to GitHub Actions for version-2.02

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: IATI/IATI-Schemas
-          ref: version-2.03
+          ref: version-2.02
           path: IATI-Schemas
 
       - name: Run schema validation with xmllint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,32 @@
+name: CI_version-2.02
+
+on:
+  push:
+    branches: [version-2.02]
+  pull_request:
+    branches: [version-2.02]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install xmllint
+        run: sudo apt-get install libxml2-utils
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          path: IATI-Extra-Documentation
+
+      - name: Checkout Schemas repo
+        uses: actions/checkout@v2
+        with:
+          repository: IATI/IATI-Schemas
+          ref: version-2.03
+          path: IATI-Schemas
+
+      - name: Run schema validation with xmllint
+        run: |
+          xmllint --schema IATI-Schemas/iati-activities-schema.xsd --noout IATI-Extra-Documentation/en/activity-standard/*.xml
+          xmllint --schema IATI-Schemas/iati-organisations-schema.xsd --noout IATI-Extra-Documentation/en/organisation-standard/*.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -qq libxml2-utils
-script:
-    - wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/iati-activities-schema.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/iati-common.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/iati-common.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/xml.xsd"; xmllint --schema iati-activities-schema.xsd --noout en/activity-standard/*.xml
-    - wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/iati-organisations-schema.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/iati-common.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/iati-common.xsd"; wget "https://raw.githubusercontent.com/IATI/IATI-Schemas/version-2.02/xml.xsd"; xmllint --schema iati-organisations-schema.xsd --noout en/organisation-standard/*.xml

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-.. image:: https://github.com/IATI/IATI-Rulesets/workflows/CI_version-2.02/badge.svg
-    :target: https://github.com/IATI/IATI-Rulesets/actions
+.. image:: https://github.com/IATI/IATI-Extra-Documentation/workflows/CI_version-2.02/badge.svg
+    :target: https://github.com/IATI/IATI-Extra-Documentation/actions
 
 This is the repository contains additional documentation about the IATI Standard, and is part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://github.com/IATI/IATI-Standard-SSOT/blob/master/meta-docs/index.rst 
 

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://github.com/IATI/IATI-Rulesets/workflows/CI_version-2.02/badge.svg
+    :target: https://github.com/IATI/IATI-Rulesets/actions
+
 This is the repository contains additional documentation about the IATI Standard, and is part of IATI Standard Single Source of Truth (SSOT). For more detailed information about the SSOT, please see https://github.com/IATI/IATI-Standard-SSOT/blob/master/meta-docs/index.rst 
 
 Whilst this is the single source for the documentation, it is probably easier to read it integrated into the website, e.g. at http://iatistandard.org/activity-standard/


### PR DESCRIPTION
## Summary
- TravisCI.org is read-only after 31 Dec 2020 so we're migrating to GitHub Actions to run the CI tests/linting.
﻿
